### PR TITLE
Move intro text, make responsive

### DIFF
--- a/src/components/MapQuestion.tsx
+++ b/src/components/MapQuestion.tsx
@@ -28,7 +28,7 @@ export const MapQuestion = (props) => {
         css={[styles.mapQuestion, cc.mapNode]}
         key={questionIndex}
         onClick={() => {
-          setMapDepth(0)
+          setMapDepth(1)
           setCurrentQuestion(question.current._key)
         }}
       >
@@ -47,7 +47,7 @@ export const MapQuestion = (props) => {
                 nodeId={childNodeKey}
                 title={childNode.title}
                 nodeChildren={childNode.childNodes}
-                depth={1}
+                depth={2}
                 setMapDepth={setMapDepth}
                 setMaxMapDepth={setMaxMapDepth}
                 isExpanded={childNodeKey === expandedChild}

--- a/src/components/MapQuestions.tsx
+++ b/src/components/MapQuestions.tsx
@@ -3,7 +3,7 @@ import { jsx } from '@emotion/core'
 import * as React from 'react'
 import { MapQuestion } from '../components/MapQuestion'
 import { MapIntro } from '../components/MapIntro'
-import { mapIntroContainer, questionList } from '../styles/MapQuestions.style'
+import { mapIntroContainer, questionList, responsiveFlex } from '../styles/MapQuestions.style'
 import { covidConversation as cc } from '../styles/CovidConversation'
 
 export const MapQuestions = (props) => {
@@ -12,7 +12,10 @@ export const MapQuestions = (props) => {
   const [currentQuestion, setCurrentQuestion] = React.useState(null)
 
   return (
-    <>
+    <div css={responsiveFlex}>
+      <div css={mapIntroContainer}>
+        <MapIntro />
+      </div>
       <ul css={[cc.questionList, questionList]}>
         {questions.map((question, questionIndex) => (
           <MapQuestion
@@ -26,11 +29,6 @@ export const MapQuestions = (props) => {
           />
         ))}
       </ul>
-      {currentQuestion === null && (
-        <div css={mapIntroContainer}>
-          <MapIntro />
-        </div>
-      )}
-    </>
+    </div>
   )
 }

--- a/src/styles/MapQuestions.style.ts
+++ b/src/styles/MapQuestions.style.ts
@@ -1,24 +1,28 @@
 import { css } from '@emotion/core'
 import { mq, textSize } from '../styles/variables'
 
+export const responsiveFlex = mq({
+  label: 'responsiveFlex',
+  display: 'flex',
+  flexDirection: ['column', 'row', 'row'],
+  alignItems: ['center', null, null],
+})
+
 export const questionList = mq({
   label: 'questionList',
   position: 'relative',
-  width: ['80%', '40%', '40%']
+  width: ['80%', '40%', '40%'],
 })
 
-// was doubled
-// needs css function for types to work
-export const mapIntroContainer = css({
-  label: 'mapIntroContainer',
-  position: 'absolute',
-  top: 0,
-  right: '10%',
-  width: '40%',
-  'h2': {
-    fontSize: textSize.L
-  },
-  'h3': {
-    padding: 0
-  }
-})
+export const mapIntroContainer = css(
+  mq({
+    label: 'mapIntroContainer',
+    width: ['80%', '40%', '40%'],
+    h2: {
+      fontSize: textSize.L,
+    },
+    h3: {
+      padding: 0,
+    },
+  }),
+)


### PR DESCRIPTION
- intro text is above questions on mobile
- intro text is to left of questions on tablet/desktop
- everything is one level deeper than it was before, which makes levels work in both desktop and mobile

Remaining issues, to solve when we look deeper into the design:
- left alignment of questions on mobile
- can't navigate backwards on mobile without buttons 
- do we want to be able to click on the intro text/is it confusing that you can't

Desktop:
![Screen Shot 2020-04-18 at 5 14 02 PM](https://user-images.githubusercontent.com/1290996/79671406-0a893e00-8198-11ea-9b6b-46f8658cc77a.png)

Mobile:
![Screen Shot 2020-04-18 at 5 14 51 PM](https://user-images.githubusercontent.com/1290996/79671422-2ab8fd00-8198-11ea-9747-5795d887c8c5.png)
![Screen Shot 2020-04-18 at 5 15 05 PM](https://user-images.githubusercontent.com/1290996/79671423-2b519380-8198-11ea-9134-cc8abbd97987.png)
